### PR TITLE
Generate interfaces for C# client classes

### DIFF
--- a/templates/csharp_client.tmpl
+++ b/templates/csharp_client.tmpl
@@ -5,7 +5,14 @@ using WebViewRPC;
 
 namespace {{.CsharpNamespace}}
 {
-    public class {{.ServiceName}}Client
+    public interface I{{.ServiceName}}Client
+    {
+        {{range .Methods}}
+        Task<{{.OutputType}}> {{.MethodName}}({{.InputType}} request);
+        {{end}}
+    }
+
+    public class {{.ServiceName}}Client : I{{.ServiceName}}Client
     {
         private readonly WebViewRpcClient _rpcClient;
 


### PR DESCRIPTION
This change introduces an interface `I{{.ServiceName}}Client` for the generated C# client. This allows for better dependency injection and testability by providing an abstraction layer.

I couldn't see a contribution guide, so please let me know if you require some changes.